### PR TITLE
#97633 - [GOUV] API reverso : changement de système de traduction puis indexation des pages traduites

### DIFF
--- a/ezbundle/Core/FormService.php
+++ b/ezbundle/Core/FormService.php
@@ -27,7 +27,7 @@ use Novactive\Bundle\FormBuilderBundle\Entity\Field;
 use Novactive\Bundle\FormBuilderBundle\Entity\Form;
 use Novactive\Bundle\FormBuilderBundle\Entity\FormSubmission;
 use Symfony\Component\HttpFoundation\File\File;
-use Symfony\Component\Translation\Translator;
+use Symfony\Component\Translation\TranslatorInterface;
 
 class FormService
 {
@@ -55,7 +55,7 @@ class FormService
     private $exporterRegistry;
 
     /**
-     * @var Translator
+     * @var TranslatorInterface
      */
     private $translator;
 
@@ -68,7 +68,7 @@ class FormService
         ContentService $contentService,
         FieldTypeRegistry $fieldTypeRegistry,
         ExporterRegistry $exporterRegistry,
-        Translator $translator
+        TranslatorInterface $translator
     ) {
         $this->connection        = $connection;
         $this->entityManager     = $entityManager;

--- a/ezbundle/Core/FormSubmissionService.php
+++ b/ezbundle/Core/FormSubmissionService.php
@@ -17,20 +17,20 @@ use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
 use IntlDateFormatter;
 use Novactive\Bundle\FormBuilderBundle\Core\FieldTypeRegistry;
 use Novactive\Bundle\FormBuilderBundle\Entity\FormSubmission;
-use Symfony\Component\Translation\Translator;
+use Symfony\Component\Translation\TranslatorInterface;
 
 class FormSubmissionService
 {
     /** @var FieldTypeRegistry */
     private $fieldTypeRegistry;
 
-    /** @var Translator */
+    /** @var TranslatorInterface */
     private $translator;
 
     /**
      * FormSubmissionService constructor.
      */
-    public function __construct(FieldTypeRegistry $fieldTypeRegistry, Translator $translator)
+    public function __construct(FieldTypeRegistry $fieldTypeRegistry, TranslatorInterface $translator)
     {
         $this->fieldTypeRegistry = $fieldTypeRegistry;
         $this->translator        = $translator;


### PR DESCRIPTION
# #97633 - [GOUV] API reverso : changement de système de traduction puis indexation des pages traduites
https://almaviacx.easyredmine.com/issues/97633

**Basé sur le tag v1.7.0**

Suite à l'installation de la dependency `lexik/translation-bundle:^4.0`

Correction des erreurs de type : 

> Cannot autowire service "SERVICE_NAME": argument "$translator" of method "__construct()" references class "Symfony\Component\Translation\Translator" but no such service exists. Try 
>    changing the type-hint to "Symfony\Component\Translation\TranslatorInterface" instead. 